### PR TITLE
fix: use ltrim to do not remove last bar

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -82,7 +82,7 @@ function locale_path($page, string $partial_path, ?string $target_locale = null)
 {
     $target_locale ??= current_path_locale($page);
 
-    $partial_path = '/'.trim($partial_path, '/');
+    $partial_path = '/'.ltrim($partial_path, '/');
 
     return match (true) {
         $target_locale === packageDefaultLocale($page) => $partial_path,

--- a/tests/unit/LocalePathTest.php
+++ b/tests/unit/LocalePathTest.php
@@ -17,6 +17,8 @@ final class LocalePathTest extends TestCase
         return [
             ['blog', null, '/blog'],
             ['blog', 'ar', '/ar/blog'],
+            ['blog/', 'ar', '/ar/blog/'],
+            ['/blog/', 'ar', '/ar/blog/'],
         ];
     }
 }


### PR DESCRIPTION
When the path ends with /, is necessary to maintain this

## todo
- [x] merge the follow PR:
  - https://github.com/LibreSign/jigsaw-localization/pull/4